### PR TITLE
remove unused benchmark configuration for parsing

### DIFF
--- a/mu-core/Cargo.toml
+++ b/mu-core/Cargo.toml
@@ -38,10 +38,6 @@ tree-sitter-c-sharp = "0.23"
 criterion = { version = "0.5", features = ["html_reports"] }
 tempfile = "3.10"       # Temporary directories for testing
 
-[[bench]]
-name = "parsing"
-harness = false
-
 [profile.release]
 lto = true
 codegen-units = 1


### PR DESCRIPTION
This pull request makes a small change by removing the parsing benchmark configuration from the `mu-core/Cargo.toml` file. No other functional code or dependencies are affected.

- Removed the `[[bench]]` section for the `parsing` benchmark, which disables the custom benchmark harness.

Fixes: https://github.com/0ximu/mu/issues/28