### PR TITLE
feat: add WorkspaceResolver for monorepo package imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,7 +2369,7 @@ dependencies = [
 
 [[package]]
 name = "mu-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,12 +52,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,33 +648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,42 +800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,8 +846,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -934,12 +875,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.111",
 ]
@@ -979,7 +945,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -1056,6 +1022,12 @@ dependencies = [
  "rust_decimal",
  "strum 0.27.2",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dyn-stack"
@@ -1286,6 +1258,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,10 +1289,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1325,8 +1334,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2011,30 +2022,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2396,6 +2387,8 @@ dependencies = [
  "petgraph",
  "regex",
  "reqwest",
+ "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "syntect",
@@ -2415,7 +2408,6 @@ name = "mu-core"
 version = "0.1.0"
 dependencies = [
  "bytecount",
- "criterion",
  "ignore",
  "once_cell",
  "petgraph",
@@ -2677,12 +2669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,34 +2803,6 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
-]
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
 ]
 
 [[package]]
@@ -3195,6 +3153,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3300,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0d0d5493be0d181a62db489eab7838669b81885972ca00ceca893cf6ac2883"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aebc912b8fa7d54999adc4e45601d1d95fe458f97eb0a1277eddcd6382cf4b1"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,6 +3444,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301858a4023d78debd2353c7426dc486001bddc91ae31a76fb1f55132f7e2633"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,6 +3534,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3957,16 +4006,6 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Yavor Kangalov <0ximu@proton.me>"]

--- a/mu-cli/Cargo.toml
+++ b/mu-cli/Cargo.toml
@@ -70,5 +70,9 @@ blake3 = "1.5"
 # Syntax highlighting
 syntect = { version = "5.2", default-features = false, features = ["default-fancy"] }
 
+# MCP server (Model Context Protocol)
+rmcp = { version = "0.3", features = ["server", "transport-io"] }
+schemars = "1.0.0-alpha.17"
+
 [dev-dependencies]
 tempfile = "3"

--- a/mu-cli/src/commands/mcp/mod.rs
+++ b/mu-cli/src/commands/mcp/mod.rs
@@ -1,0 +1,69 @@
+//! MCP command - Model Context Protocol server for AI assistant integration
+//!
+//! Exposes MU capabilities as MCP tools that AI assistants like Claude can use
+//! to understand and query codebases.
+
+mod server;
+
+use std::path::Path;
+use rmcp::{transport::stdio, ServiceExt};
+
+pub use server::MuMcpServer;
+
+/// Find the mubase path starting from the given directory
+fn find_mubase_path(start_dir: &Path) -> Option<std::path::PathBuf> {
+    let mut current = start_dir.to_path_buf();
+    loop {
+        let mubase_path = current.join(".mu").join("mubase");
+        if mubase_path.exists() {
+            return Some(mubase_path);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+/// Find the project root (directory containing .mu)
+fn find_project_root(start_dir: &Path) -> Option<std::path::PathBuf> {
+    let mut current = start_dir.to_path_buf();
+    loop {
+        let mu_dir = current.join(".mu");
+        if mu_dir.exists() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+/// Run the MCP server
+pub async fn run(path: &str) -> anyhow::Result<()> {
+    let start_dir = if path == "." {
+        std::env::current_dir()?
+    } else {
+        std::fs::canonicalize(path)?
+    };
+
+    // Find project root and mubase
+    let project_root = find_project_root(&start_dir)
+        .ok_or_else(|| anyhow::anyhow!("No .mu directory found. Run 'mu bootstrap' first."))?;
+
+    let mubase_path = find_mubase_path(&start_dir)
+        .ok_or_else(|| anyhow::anyhow!("No .mu/mubase found. Run 'mu bootstrap' first."))?;
+
+    // Open database in read-only mode
+    let mubase = mu_daemon::storage::MUbase::open_read_only(&mubase_path)?;
+
+    // Create and run MCP server
+    let server = MuMcpServer::new(mubase, project_root);
+
+    // Serve over stdio
+    let running_server = server.serve(stdio()).await?;
+
+    // Wait for client to disconnect
+    running_server.waiting().await?;
+
+    Ok(())
+}

--- a/mu-cli/src/commands/mcp/server.rs
+++ b/mu-cli/src/commands/mcp/server.rs
@@ -1,0 +1,799 @@
+//! MCP Server implementation for MU
+//!
+//! Exposes MU capabilities as MCP tools that can be called by AI assistants.
+
+use std::fs;
+use std::future::Future;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Instant;
+
+use rmcp::{
+    ServerHandler,
+    handler::server::{router::tool::ToolRouter, tool::Parameters},
+    model::{ErrorData as McpError, *},
+    tool, tool_router, tool_handler,
+    schemars::JsonSchema,
+};
+use serde::Deserialize;
+use tokio::sync::OnceCell;
+
+/// MU MCP Server - exposes codebase intelligence tools
+#[derive(Clone)]
+pub struct MuMcpServer {
+    mubase: Arc<mu_daemon::storage::MUbase>,
+    model: Arc<OnceCell<mu_embeddings::MuSigmaModel>>,
+    project_root: PathBuf,
+    tool_router: ToolRouter<MuMcpServer>,
+}
+
+// Tool parameter structs
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GrokParams {
+    /// Natural language question about the codebase (e.g., "how does authentication work")
+    #[schemars(description = "Natural language question about the codebase")]
+    pub query: String,
+    /// Number of code snippets to return (default: 3)
+    #[schemars(description = "Number of results to return (1-10, default: 3)")]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindParams {
+    /// Exact symbol name to find (function, class, module)
+    #[schemars(description = "Exact symbol name to find (e.g., 'parse_config', 'UserService')")]
+    pub symbol: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ImpactParams {
+    /// Symbol name to analyze for downstream dependencies
+    #[schemars(description = "Symbol name to analyze (e.g., 'DatabaseConnection')")]
+    pub symbol: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DiffParams {
+    /// Base git ref to compare against (branch, commit, tag). Defaults to 'main' or 'master'.
+    #[schemars(description = "Base git ref (e.g., 'main', 'HEAD~5', 'v1.0.0')")]
+    pub base_ref: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct WtfParams {
+    /// File path to investigate history for
+    #[schemars(description = "File path to investigate (e.g., 'src/auth/login.rs')")]
+    pub file: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SusParams {
+    /// Minimum complexity threshold (default: 15)
+    #[schemars(description = "Minimum complexity score to flag (default: 15)")]
+    pub min_complexity: Option<i64>,
+}
+
+#[tool_router]
+impl MuMcpServer {
+    pub fn new(mubase: mu_daemon::storage::MUbase, project_root: PathBuf) -> Self {
+        Self {
+            mubase: Arc::new(mubase),
+            model: Arc::new(OnceCell::new()),
+            project_root,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Grok: Semantic search with actual code snippets
+    #[tool(description = "Find and show relevant code for a question. Returns actual code snippets, not just locations. Use this to understand how something works.")]
+    async fn mu_grok(&self, Parameters(params): Parameters<GrokParams>) -> Result<CallToolResult, McpError> {
+        let start = Instant::now();
+        let limit = params.limit.unwrap_or(3).min(10).max(1);
+
+        // Get search results
+        let results = if self.mubase.has_embeddings().unwrap_or(false) {
+            self.run_semantic_search(&params.query, limit).await.unwrap_or_default()
+        } else {
+            self.run_keyword_search(&params.query, limit).unwrap_or_default()
+        };
+
+        let mut output = String::new();
+        output.push_str(&format!("# grok: \"{}\"\n", params.query));
+        output.push_str(&format!("# {} results in {}ms\n\n", results.len(), start.elapsed().as_millis()));
+
+        // For each result, read and show the actual code
+        for (i, result) in results.iter().enumerate() {
+            let sigil = match result.node_type.as_str() {
+                "module" => "!",
+                "class" => "$",
+                "function" => "#",
+                _ => "@",
+            };
+
+            output.push_str(&format!(
+                "## {}. {}{} [{}] — {:.0}% match\n",
+                i + 1, sigil, result.name, result.node_type,
+                result.similarity * 100.0
+            ));
+
+            if let Some(ref path) = result.file_path {
+                output.push_str(&format!("File: {}\n", path));
+
+                // Read and show actual code snippet
+                let full_path = self.project_root.join(path);
+                if let Ok(content) = fs::read_to_string(&full_path) {
+                    if let Some(snippet) = self.extract_snippet(&content, &result.name, &result.node_type) {
+                        output.push_str("```\n");
+                        output.push_str(&snippet);
+                        if !snippet.ends_with('\n') {
+                            output.push('\n');
+                        }
+                        output.push_str("```\n");
+                    }
+                }
+            }
+            output.push('\n');
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+
+    /// Find: Exact symbol lookup with code
+    #[tool(description = "Find a specific symbol by exact name. Use this when you know the function/class name you're looking for.")]
+    async fn mu_find(&self, Parameters(params): Parameters<FindParams>) -> Result<CallToolResult, McpError> {
+        let sql = format!(
+            "SELECT type, name, file_path, line_start, line_end FROM nodes WHERE name = '{}' OR name LIKE '%.{}' LIMIT 10",
+            params.symbol.replace('\'', "''"),
+            params.symbol.replace('\'', "''")
+        );
+
+        let result = self.mubase.query(&sql)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let mut output = String::new();
+        output.push_str(&format!("# find: \"{}\"\n", params.symbol));
+        output.push_str(&format!("# {} matches\n\n", result.rows.len()));
+
+        for row in &result.rows {
+            let node_type = row.get(0).and_then(|v| v.as_str()).unwrap_or("?");
+            let name = row.get(1).and_then(|v| v.as_str()).unwrap_or("?");
+            let file_path = row.get(2).and_then(|v| v.as_str()).unwrap_or("?");
+            let start_line = row.get(3).and_then(|v| v.as_i64()).unwrap_or(0);
+            let end_line = row.get(4).and_then(|v| v.as_i64()).unwrap_or(0);
+
+            let sigil = match node_type {
+                "module" => "!",
+                "class" => "$",
+                "function" => "#",
+                _ => "@",
+            };
+
+            output.push_str(&format!("## {}{} [{}]\n", sigil, name, node_type));
+            output.push_str(&format!("{}:{}-{}\n", file_path, start_line, end_line));
+
+            // Show the actual code
+            let full_path = self.project_root.join(file_path);
+            if let Ok(content) = fs::read_to_string(&full_path) {
+                let lines: Vec<&str> = content.lines().collect();
+                let start = (start_line as usize).saturating_sub(1);
+                let end = (end_line as usize).min(lines.len());
+                if start < lines.len() {
+                    output.push_str("```\n");
+                    for line in &lines[start..end.min(start + 30)] {
+                        output.push_str(line);
+                        output.push('\n');
+                    }
+                    if end > start + 30 {
+                        output.push_str("... (truncated)\n");
+                    }
+                    output.push_str("```\n");
+                }
+            }
+            output.push('\n');
+        }
+
+        if result.rows.is_empty() {
+            output.push_str("No exact matches. Try mu_grok for semantic search.\n");
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+
+    /// Compress: Token-efficient codebase overview
+    #[tool(description = "Get a compressed overview of the entire codebase structure. Use this first to understand what's in the project.")]
+    async fn mu_compress(&self) -> Result<CallToolResult, McpError> {
+        // Get stats
+        let stats = self.mubase.query("SELECT
+            (SELECT COUNT(*) FROM nodes) as nodes,
+            (SELECT COUNT(*) FROM edges) as edges,
+            (SELECT COUNT(DISTINCT file_path) FROM nodes) as files")
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let (node_count, edge_count, file_count) = stats.rows.first()
+            .map(|r| (
+                r.get(0).and_then(|v| v.as_i64()).unwrap_or(0),
+                r.get(1).and_then(|v| v.as_i64()).unwrap_or(0),
+                r.get(2).and_then(|v| v.as_i64()).unwrap_or(0),
+            ))
+            .unwrap_or((0, 0, 0));
+
+        // Detect languages
+        let langs = self.mubase.query("SELECT DISTINCT
+            CASE
+                WHEN file_path LIKE '%.rs' THEN 'Rust'
+                WHEN file_path LIKE '%.py' THEN 'Python'
+                WHEN file_path LIKE '%.ts' THEN 'TypeScript'
+                WHEN file_path LIKE '%.js' THEN 'JavaScript'
+                WHEN file_path LIKE '%.go' THEN 'Go'
+                WHEN file_path LIKE '%.java' THEN 'Java'
+                WHEN file_path LIKE '%.cs' THEN 'C#'
+                ELSE 'Other'
+            END as lang
+            FROM nodes WHERE file_path IS NOT NULL")
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let languages: Vec<String> = langs.rows.iter()
+            .filter_map(|r| r.get(0).and_then(|v| v.as_str()).map(|s| s.to_string()))
+            .filter(|s| s != "Other")
+            .collect();
+
+        let mut output = String::new();
+        output.push_str("# MU Codebase Overview\n\n");
+        output.push_str(&format!("Files: {} | Symbols: {} | Edges: {}\n", file_count, node_count, edge_count));
+        output.push_str(&format!("Languages: {}\n\n", if languages.is_empty() { "Unknown".to_string() } else { languages.join(", ") }));
+
+        // Get structure grouped by directory
+        let nodes_result = self.mubase.query(
+            "SELECT type, name, file_path, complexity FROM nodes ORDER BY file_path, type DESC, name LIMIT 500")
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let mut current_dir = String::new();
+        let mut current_file = String::new();
+
+        for row in &nodes_result.rows {
+            let node_type = row.get(0).and_then(|v| v.as_str()).unwrap_or("");
+            let name = row.get(1).and_then(|v| v.as_str()).unwrap_or("");
+            let file_path = row.get(2).and_then(|v| v.as_str()).unwrap_or("");
+            let complexity = row.get(3).and_then(|v| v.as_i64()).unwrap_or(0);
+
+            // Track directory changes
+            let dir = file_path.rsplit_once('/').map(|(d, _)| d).unwrap_or("");
+            if dir != current_dir && !dir.is_empty() {
+                current_dir = dir.to_string();
+                output.push_str(&format!("\n## {}/\n", dir));
+            }
+
+            // Track file changes
+            if file_path != current_file && !file_path.is_empty() {
+                current_file = file_path.to_string();
+                let filename = file_path.rsplit_once('/').map(|(_, f)| f).unwrap_or(file_path);
+                output.push_str(&format!("  ! {}\n", filename));
+            }
+
+            let sigil = match node_type {
+                "module" => continue, // Skip module entries, we show files
+                "class" => "$",
+                "function" => "#",
+                _ => "@",
+            };
+
+            let complexity_indicator = if complexity > 20 { " ⚠" } else { "" };
+            output.push_str(&format!("    {}{}{}\n", sigil, name, complexity_indicator));
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+
+    /// Impact: What depends on this symbol (with grep fallback)
+    #[tool(description = "Find what code depends on a symbol. Shows what might break if you change it.")]
+    async fn mu_impact(&self, Parameters(params): Parameters<ImpactParams>) -> Result<CallToolResult, McpError> {
+        let mut output = String::new();
+        output.push_str(&format!("# Impact Analysis: {}\n\n", params.symbol));
+
+        // First, try the graph-based approach
+        let sql = format!(
+            "SELECT DISTINCT n.name, n.type, n.file_path FROM edges e
+             JOIN nodes n ON n.id = e.source_id
+             WHERE e.target_id IN (SELECT id FROM nodes WHERE name = '{}')
+             LIMIT 50",
+            params.symbol.replace('\'', "''")
+        );
+
+        let result = self.mubase.query(&sql)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        let graph_count = result.rows.len();
+
+        if graph_count > 0 {
+            output.push_str(&format!("## Graph Dependencies ({} found)\n", graph_count));
+            for row in &result.rows {
+                let name = row.get(0).and_then(|v| v.as_str()).unwrap_or("?");
+                let node_type = row.get(1).and_then(|v| v.as_str()).unwrap_or("?");
+                let file_path = row.get(2).and_then(|v| v.as_str()).unwrap_or("?");
+                output.push_str(&format!("  {} [{}] — {}\n", name, node_type, file_path));
+            }
+            output.push('\n');
+        }
+
+        // If graph is sparse, supplement with grep
+        if graph_count < 5 {
+            output.push_str("## Text References (grep)\n");
+
+            let grep_result = Command::new("grep")
+                .args(["-rn", "--include=*.rs", "--include=*.py", "--include=*.ts",
+                       "--include=*.js", "--include=*.go", "--include=*.java",
+                       "-l", &params.symbol])
+                .current_dir(&self.project_root)
+                .output();
+
+            if let Ok(grep_out) = grep_result {
+                let files = String::from_utf8_lossy(&grep_out.stdout);
+                let file_list: Vec<&str> = files.lines().take(20).collect();
+
+                if file_list.is_empty() {
+                    output.push_str("  No text references found.\n");
+                } else {
+                    output.push_str(&format!("  Found in {} files:\n", file_list.len()));
+                    for file in file_list {
+                        output.push_str(&format!("    {}\n", file));
+                    }
+
+                    // Show a sample of actual usages
+                    output.push_str("\n## Sample Usages\n");
+                    let context_result = Command::new("grep")
+                        .args(["-rn", "--include=*.rs", "--include=*.py", "--include=*.ts",
+                               "--include=*.js", "--include=*.go", "--include=*.java",
+                               "-C1", &params.symbol])
+                        .current_dir(&self.project_root)
+                        .output();
+
+                    if let Ok(ctx) = context_result {
+                        let context = String::from_utf8_lossy(&ctx.stdout);
+                        let lines: Vec<&str> = context.lines().take(30).collect();
+                        output.push_str("```\n");
+                        for line in lines {
+                            output.push_str(line);
+                            output.push('\n');
+                        }
+                        output.push_str("```\n");
+                    }
+                }
+            }
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+
+    /// Diff: Semantic diff showing what changed
+    #[tool(description = "See what symbols changed between git refs. Shows functions/classes added, modified, or removed.")]
+    async fn mu_diff(&self, Parameters(params): Parameters<DiffParams>) -> Result<CallToolResult, McpError> {
+        // Detect default branch
+        let base = params.base_ref.unwrap_or_else(|| {
+            let result = Command::new("git")
+                .args(["symbolic-ref", "refs/remotes/origin/HEAD"])
+                .current_dir(&self.project_root)
+                .output();
+
+            result.ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .and_then(|s| s.trim().rsplit('/').next().map(|s| s.to_string()))
+                .unwrap_or_else(|| "main".to_string())
+        });
+
+        let mut output = String::new();
+        output.push_str(&format!("# Semantic Diff: {} → HEAD\n\n", base));
+
+        // Get changed files
+        let diff_result = Command::new("git")
+            .args(["diff", "--name-status", &base, "HEAD"])
+            .current_dir(&self.project_root)
+            .output()
+            .map_err(|e| McpError::internal_error(format!("git error: {}", e), None))?;
+
+        let diff_output = String::from_utf8_lossy(&diff_result.stdout);
+
+        let mut added_files = Vec::new();
+        let mut modified_files = Vec::new();
+        let mut deleted_files = Vec::new();
+
+        for line in diff_output.lines() {
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() >= 2 {
+                let status = parts[0];
+                let file = parts[1];
+                match status.chars().next() {
+                    Some('A') => added_files.push(file),
+                    Some('M') => modified_files.push(file),
+                    Some('D') => deleted_files.push(file),
+                    _ => {}
+                }
+            }
+        }
+
+        let total = added_files.len() + modified_files.len() + deleted_files.len();
+        output.push_str(&format!("{} files changed: +{} ~{} -{}\n\n",
+            total, added_files.len(), modified_files.len(), deleted_files.len()));
+
+        // For each modified file, show what symbols changed
+        if !modified_files.is_empty() {
+            output.push_str("## Modified Files\n");
+            for file in modified_files.iter().take(10) {
+                output.push_str(&format!("\n### {}\n", file));
+
+                // Get symbols in this file
+                let sql = format!(
+                    "SELECT type, name FROM nodes WHERE file_path = '{}' ORDER BY line_start",
+                    file.replace('\'', "''")
+                );
+                if let Ok(nodes) = self.mubase.query(&sql) {
+                    let symbols: Vec<String> = nodes.rows.iter()
+                        .filter_map(|r| {
+                            let t = r.get(0).and_then(|v| v.as_str())?;
+                            let n = r.get(1).and_then(|v| v.as_str())?;
+                            if t == "module" { return None; }
+                            let sigil = match t { "class" => "$", "function" => "#", _ => "@" };
+                            Some(format!("{}{}", sigil, n))
+                        })
+                        .collect();
+
+                    if !symbols.is_empty() {
+                        output.push_str(&format!("  Contains: {}\n", symbols.join(", ")));
+                    }
+                }
+            }
+        }
+
+        if !added_files.is_empty() {
+            output.push_str("\n## Added Files\n");
+            for file in added_files.iter().take(10) {
+                output.push_str(&format!("  + {}\n", file));
+            }
+        }
+
+        if !deleted_files.is_empty() {
+            output.push_str("\n## Deleted Files\n");
+            for file in deleted_files.iter().take(10) {
+                output.push_str(&format!("  - {}\n", file));
+            }
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+
+    /// Sus: Find suspicious code with categories
+    #[tool(description = "Find suspicious code: high complexity, security-sensitive names, large functions. Good for code review.")]
+    async fn mu_sus(&self, Parameters(params): Parameters<SusParams>) -> Result<CallToolResult, McpError> {
+        let min_complexity = params.min_complexity.unwrap_or(15);
+
+        let mut output = String::new();
+        output.push_str("# Suspicious Code Report\n\n");
+
+        // High complexity
+        let complex_sql = format!(
+            "SELECT name, type, file_path, complexity FROM nodes
+             WHERE complexity >= {} AND type = 'function'
+             ORDER BY complexity DESC LIMIT 15",
+            min_complexity
+        );
+        let complex = self.mubase.query(&complex_sql)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        if !complex.rows.is_empty() {
+            output.push_str(&format!("## High Complexity (≥{}) — {} found\n", min_complexity, complex.rows.len()));
+            output.push_str("Functions that are hard to understand and maintain:\n\n");
+            for row in &complex.rows {
+                let name = row.get(0).and_then(|v| v.as_str()).unwrap_or("?");
+                let file_path = row.get(2).and_then(|v| v.as_str()).unwrap_or("?");
+                let complexity = row.get(3).and_then(|v| v.as_i64()).unwrap_or(0);
+                output.push_str(&format!("  #{} c={} — {}\n", name, complexity, file_path));
+            }
+            output.push('\n');
+        }
+
+        // Security-sensitive
+        let security_sql = "SELECT name, type, file_path FROM nodes
+            WHERE LOWER(name) LIKE '%auth%'
+               OR LOWER(name) LIKE '%token%'
+               OR LOWER(name) LIKE '%password%'
+               OR LOWER(name) LIKE '%secret%'
+               OR LOWER(name) LIKE '%crypt%'
+               OR LOWER(name) LIKE '%credential%'
+               OR LOWER(name) LIKE '%api_key%'
+            ORDER BY file_path LIMIT 20";
+        let security = self.mubase.query(security_sql)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        if !security.rows.is_empty() {
+            output.push_str(&format!("## Security-Sensitive — {} found\n", security.rows.len()));
+            output.push_str("Code handling authentication, secrets, or credentials:\n\n");
+            for row in &security.rows {
+                let name = row.get(0).and_then(|v| v.as_str()).unwrap_or("?");
+                let node_type = row.get(1).and_then(|v| v.as_str()).unwrap_or("?");
+                let file_path = row.get(2).and_then(|v| v.as_str()).unwrap_or("?");
+                let sigil = match node_type { "class" => "$", "function" => "#", _ => "@" };
+                output.push_str(&format!("  {}{} — {}\n", sigil, name, file_path));
+            }
+            output.push('\n');
+        }
+
+        // Large functions (by line count if available)
+        let large_sql = "SELECT name, file_path, (line_end - line_start) as lines FROM nodes
+            WHERE type = 'function' AND line_end > line_start
+            ORDER BY lines DESC LIMIT 10";
+        if let Ok(large) = self.mubase.query(large_sql) {
+            if !large.rows.is_empty() {
+                output.push_str("## Large Functions (by lines)\n");
+                output.push_str("Long functions that might need refactoring:\n\n");
+                for row in &large.rows {
+                    let name = row.get(0).and_then(|v| v.as_str()).unwrap_or("?");
+                    let file_path = row.get(1).and_then(|v| v.as_str()).unwrap_or("?");
+                    let lines = row.get(2).and_then(|v| v.as_i64()).unwrap_or(0);
+                    if lines > 50 {
+                        output.push_str(&format!("  #{} ({} lines) — {}\n", name, lines, file_path));
+                    }
+                }
+            }
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+
+    /// WTF: Git archaeology with context
+    #[tool(description = "Understand why code exists. Shows git history, recent changes, and who works on a file.")]
+    async fn mu_wtf(&self, Parameters(params): Parameters<WtfParams>) -> Result<CallToolResult, McpError> {
+        let file_path = &params.file;
+        let full_path = self.project_root.join(file_path);
+
+        let mut output = String::new();
+        output.push_str(&format!("# WTF: {}\n\n", file_path));
+
+        // Check if file exists
+        let file_exists = full_path.exists();
+        let is_tracked = Command::new("git")
+            .args(["ls-files", file_path])
+            .current_dir(&self.project_root)
+            .output()
+            .map(|o| !o.stdout.is_empty())
+            .unwrap_or(false);
+
+        // File info
+        if file_exists {
+            if let Ok(metadata) = fs::metadata(&full_path) {
+                let size = metadata.len();
+                output.push_str(&format!("Size: {} bytes\n", size));
+            }
+            if let Ok(content) = fs::read_to_string(&full_path) {
+                let lines = content.lines().count();
+                output.push_str(&format!("Lines: {}\n", lines));
+            }
+        } else {
+            output.push_str("⚠ File not found on disk\n");
+        }
+
+        output.push_str(&format!("Git tracked: {}\n\n", if is_tracked { "Yes" } else { "No" }));
+
+        if is_tracked {
+            // Recent commits
+            output.push_str("## Recent Commits\n");
+            let log = Command::new("git")
+                .args(["log", "--format=%h %ad %an: %s", "--date=short", "-10", "--", file_path])
+                .current_dir(&self.project_root)
+                .output();
+
+            if let Ok(log_out) = log {
+                let log_str = String::from_utf8_lossy(&log_out.stdout);
+                if log_str.is_empty() {
+                    output.push_str("  No commits yet (new file?)\n");
+                } else {
+                    for line in log_str.lines() {
+                        output.push_str(&format!("  {}\n", line));
+                    }
+                }
+            }
+
+            // Contributors
+            output.push_str("\n## Contributors\n");
+            let authors = Command::new("git")
+                .args(["shortlog", "-sn", "--", file_path])
+                .current_dir(&self.project_root)
+                .output();
+
+            if let Ok(auth_out) = authors {
+                let auth_str = String::from_utf8_lossy(&auth_out.stdout);
+                for line in auth_str.lines().take(5) {
+                    output.push_str(&format!("  {}\n", line.trim()));
+                }
+            }
+
+            // First created
+            output.push_str("\n## Origin\n");
+            let first = Command::new("git")
+                .args(["log", "--format=%ad %an: %s", "--date=short", "--diff-filter=A", "--", file_path])
+                .current_dir(&self.project_root)
+                .output();
+
+            if let Ok(first_out) = first {
+                let first_str = String::from_utf8_lossy(&first_out.stdout);
+                if let Some(line) = first_str.lines().last() {
+                    output.push_str(&format!("  Created: {}\n", line));
+                }
+            }
+        } else if file_exists {
+            output.push_str("## Status: Untracked file\n");
+            output.push_str("This file exists but isn't in git yet.\n");
+
+            // Show first few lines
+            if let Ok(content) = fs::read_to_string(&full_path) {
+                output.push_str("\n## Preview\n```\n");
+                for line in content.lines().take(10) {
+                    output.push_str(line);
+                    output.push('\n');
+                }
+                output.push_str("```\n");
+            }
+        }
+
+        // Database info
+        let sql = format!(
+            "SELECT type, name, complexity FROM nodes WHERE file_path = '{}' ORDER BY line_start",
+            file_path.replace('\'', "''")
+        );
+        if let Ok(nodes) = self.mubase.query(&sql) {
+            if !nodes.rows.is_empty() {
+                output.push_str("\n## Symbols in file\n");
+                for row in &nodes.rows {
+                    let node_type = row.get(0).and_then(|v| v.as_str()).unwrap_or("?");
+                    let name = row.get(1).and_then(|v| v.as_str()).unwrap_or("?");
+                    let complexity = row.get(2).and_then(|v| v.as_i64()).unwrap_or(0);
+                    if node_type == "module" { continue; }
+                    let sigil = match node_type { "class" => "$", "function" => "#", _ => "@" };
+                    output.push_str(&format!("  {}{}", sigil, name));
+                    if complexity > 15 {
+                        output.push_str(&format!(" (c={})", complexity));
+                    }
+                    output.push('\n');
+                }
+            }
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
+    }
+}
+
+// Helper methods
+impl MuMcpServer {
+    async fn run_semantic_search(&self, query: &str, limit: usize) -> anyhow::Result<Vec<SearchResult>> {
+        let model = self.model
+            .get_or_try_init(|| async { mu_embeddings::MuSigmaModel::embedded() })
+            .await?;
+        let embedding = model.embed_one(query)?;
+        let results = self.mubase.vector_search(&embedding, limit, Some(0.3))?;
+
+        Ok(results.into_iter().map(|r| SearchResult {
+            name: r.name,
+            node_type: r.node_type,
+            file_path: r.file_path,
+            start_line: None,
+            end_line: None,
+            similarity: r.similarity,
+        }).collect())
+    }
+
+    fn run_keyword_search(&self, query: &str, limit: usize) -> anyhow::Result<Vec<SearchResult>> {
+        let sql = format!(
+            "SELECT type, name, file_path, line_start, line_end FROM nodes WHERE LOWER(name) LIKE '%{}%' LIMIT {}",
+            query.to_lowercase().replace('\'', "''"), limit
+        );
+        let result = self.mubase.query(&sql)?;
+
+        Ok(result.rows.iter().map(|row| SearchResult {
+            name: row.get(1).and_then(|v| v.as_str()).unwrap_or("").to_string(),
+            node_type: row.get(0).and_then(|v| v.as_str()).unwrap_or("").to_string(),
+            file_path: row.get(2).and_then(|v| v.as_str()).map(|s| s.to_string()),
+            start_line: row.get(3).and_then(|v| v.as_i64()),
+            end_line: row.get(4).and_then(|v| v.as_i64()),
+            similarity: 1.0,
+        }).collect())
+    }
+
+    /// Extract a code snippet around a symbol
+    fn extract_snippet(&self, content: &str, name: &str, node_type: &str) -> Option<String> {
+        let lines: Vec<&str> = content.lines().collect();
+
+        // Find the line containing the symbol definition
+        let patterns: Vec<String> = match node_type {
+            "function" => vec![
+                format!("fn {}", name),
+                format!("def {}(", name),
+                format!("func {}", name),
+                format!("function {}", name),
+                format!("{} = function", name),
+                format!("{} = (", name),
+                format!("{} = async", name),
+            ],
+            "class" => vec![
+                format!("class {}", name),
+                format!("struct {}", name),
+                format!("interface {}", name),
+                format!("type {} ", name),
+            ],
+            _ => vec![name.to_string()],
+        };
+
+        for (i, line) in lines.iter().enumerate() {
+            for pattern in &patterns {
+                if line.contains(pattern.as_str()) {
+                    // Found it, extract context
+                    let start = i;
+                    let mut end = i + 1;
+
+                    // Try to find the end of the block (simple heuristic)
+                    let mut brace_count = 0;
+                    let mut found_open = false;
+                    for j in i..lines.len().min(i + 50) {
+                        let l = lines[j];
+                        for c in l.chars() {
+                            if c == '{' || c == '(' && !found_open {
+                                brace_count += 1;
+                                found_open = true;
+                            } else if c == '}' || (c == ')' && found_open && brace_count == 1) {
+                                brace_count -= 1;
+                            }
+                        }
+                        end = j + 1;
+                        if found_open && brace_count <= 0 {
+                            break;
+                        }
+                    }
+
+                    // Limit to 25 lines
+                    let snippet_end = end.min(start + 25);
+                    let mut snippet = lines[start..snippet_end].join("\n");
+                    if end > snippet_end {
+                        snippet.push_str("\n  // ... (truncated)");
+                    }
+                    return Some(snippet);
+                }
+            }
+        }
+
+        None
+    }
+}
+
+#[derive(Debug, Default)]
+struct SearchResult {
+    name: String,
+    node_type: String,
+    file_path: Option<String>,
+    start_line: Option<i64>,
+    end_line: Option<i64>,
+    similarity: f32,
+}
+
+#[tool_handler]
+impl ServerHandler for MuMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: Default::default(),
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .build(),
+            server_info: Implementation {
+                name: "mu".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+            },
+            instructions: Some(
+                "MU - semantic code intelligence. Tools:\n\
+                 • mu_grok: Understand code (semantic search + snippets)\n\
+                 • mu_find: Find exact symbol by name\n\
+                 • mu_compress: Get codebase overview\n\
+                 • mu_impact: What depends on a symbol\n\
+                 • mu_diff: What changed between git refs\n\
+                 • mu_sus: Find suspicious/complex code\n\
+                 • mu_wtf: Git archaeology for a file".into()
+            ),
+        }
+    }
+}

--- a/mu-cli/src/commands/mod.rs
+++ b/mu-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod export;
 pub mod graph;
 pub mod grok;
 pub mod history;
+pub mod mcp;
 pub mod patterns;
 pub mod query;
 pub mod read;

--- a/mu-cli/src/main.rs
+++ b/mu-cli/src/main.rs
@@ -397,6 +397,14 @@ enum Commands {
         limit: usize,
     },
 
+    // ==================== Integration ====================
+    /// Start MCP server for AI assistant integration (Claude, etc.)
+    Mcp {
+        /// Working directory (defaults to current)
+        #[arg(default_value = ".")]
+        path: String,
+    },
+
     // ==================== Utilities ====================
     /// Run health checks on MU installation
     Doctor {
@@ -604,6 +612,9 @@ async fn main() -> anyhow::Result<()> {
         }
 
         Commands::History { node, limit } => history::run(&node, limit, format).await,
+
+        // Integration commands
+        Commands::Mcp { path } => mcp::run(&path).await,
 
         // Utility commands
         Commands::Doctor { path } => doctor::run(&path, format).await,

--- a/mu-core/Cargo.toml
+++ b/mu-core/Cargo.toml
@@ -35,12 +35,7 @@ tree-sitter-rust = "0.23"
 tree-sitter-c-sharp = "0.23"
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
 tempfile = "3.10"       # Temporary directories for testing
-
-[[bench]]
-name = "parsing"
-harness = false
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Resolves monorepo workspace packages (like `@expo-mockup-shell/ui`) to their actual internal file paths instead of marking them as external.

**What it does:**
- New `WorkspaceResolver` struct in `tsconfig.rs`
- Reads `package.json` workspaces field
- Expands glob patterns (`packages/*`, `apps/*`) 
- Maps package names → entry points (exports, module, main, src/index.ts)
- Integrates into import resolution pipeline

**Before:**
```
mu deps ProfileScreen
  [external] @expo-mockup-shell/ui
  [external] @expo-mockup-shell/auth
```

**After:**
```
mu deps ProfileScreen  
  [mod] packages/ui/src/index.ts
  [mod] packages/auth/src/index.ts
```

Tested on expo-shell monorepo - workspace packages now resolve correctly.