### PR TITLE
Fix #41-#44: staleness noise, mu_find ranking, FLOAT truncation, callback and typed-receiver edges

### DIFF
--- a/mu-cli/src/commands/bootstrap.rs
+++ b/mu-cli/src/commands/bootstrap.rs
@@ -1097,6 +1097,7 @@ fn resolve_all_call_sites(
             for class in &module.classes {
                 for method in &class.methods {
                     let method_id = format!("fn:{}:{}.{}", rel_path, class.name, method.name);
+                    let param_types = param_type_map(&method.parameters);
                     total += method.call_sites.len();
                     for call in &method.call_sites {
                         if let Some(target_id) = resolve_call_site(
@@ -1104,11 +1105,20 @@ fn resolve_all_call_sites(
                             rel_path,
                             Some(&class.name),
                             &module.imports,
+                            &param_types,
                             maps,
                         ) {
                             edges.push(crate::engine::storage::Edge::calls(&method_id, &target_id));
                             resolved += 1;
                         }
+                        push_arg_ref_edges(
+                            call,
+                            &method_id,
+                            rel_path,
+                            &module.imports,
+                            maps,
+                            edges,
+                        );
                     }
                 }
             }
@@ -1116,20 +1126,47 @@ fn resolve_all_call_sites(
             // Module-level functions
             for func in &module.functions {
                 let func_id = format!("fn:{}:{}", rel_path, func.name);
+                let param_types = param_type_map(&func.parameters);
                 total += func.call_sites.len();
                 for call in &func.call_sites {
                     if let Some(target_id) =
-                        resolve_call_site(call, rel_path, None, &module.imports, maps)
+                        resolve_call_site(call, rel_path, None, &module.imports, &param_types, maps)
                     {
                         edges.push(crate::engine::storage::Edge::calls(&func_id, &target_id));
                         resolved += 1;
                     }
+                    push_arg_ref_edges(call, &func_id, rel_path, &module.imports, maps, edges);
                 }
             }
         }
     }
 
     (total, resolved)
+}
+
+/// Emit `uses` edges for function references passed as call arguments
+/// (callback registration: `event.listen(Session, "do_orm_execute", hook)`).
+/// Impact BFS traverses all edge types, so the hook stops looking like dead
+/// weight the moment something registers it.
+fn push_arg_ref_edges(
+    call: &mu_core::types::CallSiteDef,
+    from_id: &str,
+    current_module: &str,
+    imports: &[mu_core::types::ImportDef],
+    maps: CallResolutionMaps<'_>,
+    edges: &mut Vec<crate::engine::storage::Edge>,
+) {
+    for arg in &call.arg_refs {
+        if let Some(target_id) = resolve_arg_ref(
+            arg,
+            current_module,
+            imports,
+            maps.func_lookup,
+            maps.python_module_index,
+        ) {
+            edges.push(crate::engine::storage::Edge::uses(from_id, &target_id));
+        }
+    }
 }
 
 // ============================================================================
@@ -2072,6 +2109,72 @@ fn resolve_import(
     }
 }
 
+/// Map parameter names to their type annotations for one function.
+fn param_type_map(params: &[mu_core::types::ParameterDef]) -> HashMap<&str, &str> {
+    params
+        .iter()
+        .filter_map(|p| p.type_annotation.as_deref().map(|t| (p.name.as_str(), t)))
+        .collect()
+}
+
+/// Extract the class name from a parameter type annotation. Handles the
+/// common spellings: `Svc`, `Optional[Svc]`, `Svc | None`, `pkg.Svc`, and
+/// quoted forward references. Returns None for anything that doesn't reduce
+/// to a plain identifier (generics like `list[Svc]` are deliberately skipped:
+/// the receiver's methods are the container's, not the element's).
+fn annotation_class_name(annotation: &str) -> Option<&str> {
+    let mut s = annotation.trim().trim_matches('"').trim_matches('\'');
+    if let Some((head, tail)) = s.split_once('|') {
+        let head = head.trim();
+        let tail = tail.trim();
+        s = if head == "None" { tail } else { head };
+    }
+    if let Some(inner) = s
+        .strip_prefix("Optional[")
+        .and_then(|r| r.strip_suffix(']'))
+    {
+        s = inner.trim();
+    }
+    let s = s.rsplit('.').next().unwrap_or(s);
+    let valid = !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || c == '_');
+    valid.then_some(s)
+}
+
+/// Resolve a bare identifier passed as a call argument to a function node.
+/// Only precise resolutions (same module, or explicitly imported name) are
+/// attempted: argument identifiers are usually plain variables, so a global
+/// bare-name fallback would fabricate edges.
+fn resolve_arg_ref(
+    arg: &str,
+    current_module: &str,
+    imports: &[mu_core::types::ImportDef],
+    func_lookup: &HashMap<String, String>,
+    python_module_index: &PythonModuleIndex,
+) -> Option<String> {
+    let local_id = format!("fn:{}:{}", current_module, arg);
+    if func_lookup.contains_key(&local_id) {
+        return Some(local_id);
+    }
+    for import in imports {
+        if import.names.contains(&arg.to_string()) {
+            let import_path = import.module.replace('.', "/");
+            let mut candidates: Vec<String> = Vec::new();
+            if let Some(resolved) = python_module_index.resolve(&import.module) {
+                candidates.push(resolved.to_string());
+            }
+            candidates.push(import_path.clone());
+            candidates.push(format!("{}.py", import_path));
+            for path in &candidates {
+                let id = format!("fn:{}:{}", path, arg);
+                if func_lookup.contains_key(&id) {
+                    return Some(id);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// The project-wide lookup tables call-site resolution needs.
 #[derive(Clone, Copy)]
 struct CallResolutionMaps<'a> {
@@ -2091,6 +2194,7 @@ fn resolve_call_site(
     current_module: &str,
     current_class: Option<&str>,
     imports: &[mu_core::types::ImportDef],
+    param_types: &HashMap<&str, &str>,
     maps: CallResolutionMaps<'_>,
 ) -> Option<String> {
     let CallResolutionMaps {
@@ -2188,6 +2292,37 @@ fn resolve_call_site(
                     resolve_inherited_method(receiver_class_id, callee, func_lookup, inherits_map)
                 {
                     return Some(inherited);
+                }
+            }
+
+            // Try the enclosing function's parameter annotations:
+            // `def go(s: Svc): s.run()` resolves through the declared type.
+            // The Python parser stores non-self attribute calls with the full
+            // dotted text as callee ("invoker.invoke"), so take the last
+            // segment as the method name.
+            if let Some(annotation) = param_types.get(receiver) {
+                if let Some(class_name) = annotation_class_name(annotation) {
+                    if let Some(class_id) = class_lookup.get(class_name) {
+                        let method_name = callee.rsplit('.').next().unwrap_or(callee);
+                        let module_path = class_id
+                            .strip_prefix("cls:")
+                            .and_then(|s| s.rsplit_once(':'))
+                            .map(|(p, _)| p)
+                            .unwrap_or(current_module);
+                        let method_id =
+                            format!("fn:{}:{}.{}", module_path, class_name, method_name);
+                        if func_lookup.contains_key(&method_id) {
+                            return Some(method_id);
+                        }
+                        if let Some(inherited) = resolve_inherited_method(
+                            class_id,
+                            method_name,
+                            func_lookup,
+                            inherits_map,
+                        ) {
+                            return Some(inherited);
+                        }
+                    }
                 }
             }
 
@@ -3192,8 +3327,16 @@ namespace Notifications {
             line: 10,
             is_method_call: true,
             receiver: Some("this._notificationsService".to_string()),
+            arg_refs: Vec::new(),
         };
-        let resolved = resolve_call_site(&call, "caller.cs", Some("Caller"), &[], maps);
+        let resolved = resolve_call_site(
+            &call,
+            "caller.cs",
+            Some("Caller"),
+            &[],
+            &HashMap::new(),
+            maps,
+        );
         assert_eq!(
             resolved.as_deref(),
             Some("fn:svc.cs:NotificationsService.SendEmailAsync"),
@@ -3206,8 +3349,16 @@ namespace Notifications {
             line: 11,
             is_method_call: true,
             receiver: Some("_notificationsService".to_string()),
+            arg_refs: Vec::new(),
         };
-        let resolved = resolve_call_site(&bare, "caller.cs", Some("Caller"), &[], maps);
+        let resolved = resolve_call_site(
+            &bare,
+            "caller.cs",
+            Some("Caller"),
+            &[],
+            &HashMap::new(),
+            maps,
+        );
         assert_eq!(
             resolved.as_deref(),
             Some("fn:svc.cs:NotificationsService.SendEmailAsync")
@@ -3438,6 +3589,7 @@ namespace Demo {
                 "src/pkg/clients/base_client.py",
                 Some("BpHttpClient"),
                 &imports,
+                &HashMap::new(),
                 maps
             ),
             Some("cls:src/pkg/auth/token_forwarding.py:TokenForwardingHandler".to_string())
@@ -3474,7 +3626,7 @@ namespace Demo {
         };
 
         assert_eq!(
-            resolve_call_site(&call, "app.py", None, &[], maps),
+            resolve_call_site(&call, "app.py", None, &[], &HashMap::new(), maps),
             Some("cls:app.py:Config".to_string())
         );
     }
@@ -3521,7 +3673,7 @@ namespace Demo {
         }];
 
         assert_eq!(
-            resolve_call_site(&call, "main.py", None, &imports, maps),
+            resolve_call_site(&call, "main.py", None, &imports, &HashMap::new(), maps),
             Some("cls:auth/handler.py:Handler".to_string())
         );
 
@@ -3537,7 +3689,116 @@ namespace Demo {
             &index,
         );
         assert_eq!(
-            resolve_call_site(&call, "main.py", None, &[], maps_ambiguous),
+            resolve_call_site(&call, "main.py", None, &[], &HashMap::new(), maps_ambiguous),
+            None
+        );
+    }
+
+    #[test]
+    fn test_annotation_class_name_spellings() {
+        assert_eq!(annotation_class_name("Svc"), Some("Svc"));
+        assert_eq!(annotation_class_name("Optional[Svc]"), Some("Svc"));
+        assert_eq!(annotation_class_name("Svc | None"), Some("Svc"));
+        assert_eq!(annotation_class_name("None | Svc"), Some("Svc"));
+        assert_eq!(annotation_class_name("pkg.mod.Svc"), Some("Svc"));
+        assert_eq!(annotation_class_name("\"Svc\""), Some("Svc"));
+        // Containers are not the receiver's type
+        assert_eq!(annotation_class_name("list[Svc]"), None);
+        assert_eq!(annotation_class_name("dict[str, Svc]"), None);
+    }
+
+    #[test]
+    fn test_resolve_call_site_annotated_param_receiver() {
+        // def go(s: Svc): s.run()  ->  edge to Svc.run
+        let results = python_parse_results(&["src/svc.py"]);
+        let index = PythonModuleIndex::build(&results);
+
+        let mut func_lookup = HashMap::new();
+        func_lookup.insert(
+            "fn:src/svc.py:Svc.run".to_string(),
+            "fn:src/svc.py:Svc.run".to_string(),
+        );
+        let receiver_type_map = HashMap::new();
+        let inherits_map = HashMap::new();
+        let mut class_lookup = HashMap::new();
+        class_lookup.insert("Svc".to_string(), "cls:src/svc.py:Svc".to_string());
+        let class_ids = HashSet::new();
+        let unique_class_names = HashMap::new();
+
+        let maps = empty_maps(
+            &func_lookup,
+            &receiver_type_map,
+            &inherits_map,
+            &class_lookup,
+            &class_ids,
+            &unique_class_names,
+            &index,
+        );
+
+        let call = mu_core::types::CallSiteDef {
+            // Python stores non-self attribute calls with the dotted text
+            callee: "s.run".to_string(),
+            is_method_call: true,
+            receiver: Some("s".to_string()),
+            ..Default::default()
+        };
+        let mut param_types = HashMap::new();
+        param_types.insert("s", "Svc");
+
+        assert_eq!(
+            resolve_call_site(&call, "src/caller.py", None, &[], &param_types, maps),
+            Some("fn:src/svc.py:Svc.run".to_string())
+        );
+
+        // Without the annotation the receiver stays unresolvable
+        assert_eq!(
+            resolve_call_site(&call, "src/caller.py", None, &[], &HashMap::new(), maps),
+            None
+        );
+    }
+
+    #[test]
+    fn test_resolve_arg_ref_local_and_imported() {
+        let results = python_parse_results(&["src/pkg/hooks.py", "src/pkg/main.py"]);
+        let index = PythonModuleIndex::build(&results);
+
+        let mut func_lookup = HashMap::new();
+        func_lookup.insert(
+            "fn:src/pkg/hooks.py:on_event".to_string(),
+            "fn:src/pkg/hooks.py:on_event".to_string(),
+        );
+        func_lookup.insert(
+            "fn:src/pkg/main.py:local_hook".to_string(),
+            "fn:src/pkg/main.py:local_hook".to_string(),
+        );
+
+        // Local function reference
+        assert_eq!(
+            resolve_arg_ref("local_hook", "src/pkg/main.py", &[], &func_lookup, &index),
+            Some("fn:src/pkg/main.py:local_hook".to_string())
+        );
+
+        // Imported function reference, resolved through the module index
+        let imports = vec![mu_core::types::ImportDef {
+            module: "hooks".to_string(),
+            names: vec!["on_event".to_string()],
+            is_from: true,
+            ..Default::default()
+        }];
+        assert_eq!(
+            resolve_arg_ref(
+                "on_event",
+                "src/pkg/main.py",
+                &imports,
+                &func_lookup,
+                &index
+            ),
+            Some("fn:src/pkg/hooks.py:on_event".to_string())
+        );
+
+        // Plain variables must not resolve
+        assert_eq!(
+            resolve_arg_ref("session", "src/pkg/main.py", &imports, &func_lookup, &index),
             None
         );
     }

--- a/mu-cli/src/commands/mcp/responses.rs
+++ b/mu-cli/src/commands/mcp/responses.rs
@@ -474,7 +474,11 @@ pub fn format_read_response(resp: &ReadResponse, project_root: &Path) -> String 
         let _ = writeln!(out, "## {}{} [{}]{}", sigil, n.name, n.kind, cat);
         let _ = writeln!(out, "id: {}", n.node_id);
         let _ = writeln!(out, "location: {}", location);
-        let _ = writeln!(out, "importance: {:.2}", n.importance);
+        let _ = writeln!(
+            out,
+            "importance: {}",
+            importance_label(n.importance, n.importance_pct)
+        );
 
         match resp.mode.as_str() {
             "signature" => {

--- a/mu-cli/src/commands/mcp/server.rs
+++ b/mu-cli/src/commands/mcp/server.rs
@@ -88,13 +88,32 @@ pub(crate) const IMPACT_TARGET_SQL: &str =
 /// Symbol lookup for mu_find: bare name, exact qualified name, dotted suffix
 /// of a qualified name, and `Class.Method` inputs via the id suffix (node ids
 /// end in `:Class.Method`).
+///
+/// Production matches rank before test/generated ones: an ambiguous name that
+/// is popular as a test-fake method (e.g. `chat` on a dozen stubs) must not
+/// crowd the real definitions out of the LIMIT window.
 pub(crate) const FIND_SYMBOL_SQL: &str =
     "SELECT type, name, file_path, line_start, line_end, node_category, id FROM nodes
      WHERE name = ?1
         OR qualified_name = ?1
         OR qualified_name LIKE '%.' || ?1
         OR id LIKE '%:' || ?1
+     ORDER BY CASE node_category
+                  WHEN 'production' THEN 0
+                  WHEN 'infrastructure' THEN 1
+                  WHEN 'generated' THEN 2
+                  ELSE 3
+              END,
+              importance_score DESC
      LIMIT 10";
+
+/// Total match count for the same predicate, so mu_find can say how many
+/// matches the LIMIT window hid.
+pub(crate) const FIND_SYMBOL_COUNT_SQL: &str = "SELECT COUNT(*) FROM nodes
+     WHERE name = ?1
+        OR qualified_name = ?1
+        OR qualified_name LIKE '%.' || ?1
+        OR id LIKE '%:' || ?1";
 
 // Tool parameter structs
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -367,13 +386,40 @@ impl MuMcpServer {
         }
         .map_err(|e| McpError::internal_error(e.to_string(), None))?;
 
+        // Total matches, so a LIMIT-truncated result can say what it hid.
+        let total_matches = if is_node_id {
+            result.rows.len()
+        } else {
+            state
+                .mubase
+                .query_params(FIND_SYMBOL_COUNT_SQL, &[&symbol.as_str()])
+                .ok()
+                .and_then(|r| {
+                    r.rows
+                        .first()
+                        .and_then(|row| row.first())
+                        .and_then(|v| v.as_i64())
+                })
+                .map(|n| n as usize)
+                .unwrap_or(result.rows.len())
+        };
+
         let mut output = String::new();
         if is_node_id {
             output.push_str(&format!("# find: \"{}\" (node ID lookup)\n", symbol));
         } else {
             output.push_str(&format!("# find: \"{}\"\n", symbol));
         }
-        output.push_str(&format!("# {} matches\n\n", result.rows.len()));
+        if total_matches > result.rows.len() {
+            output.push_str(&format!(
+                "# {} matches ({} shown, production-first; {} omitted - use a full node id to disambiguate)\n\n",
+                total_matches,
+                result.rows.len(),
+                total_matches - result.rows.len()
+            ));
+        } else {
+            output.push_str(&format!("# {} matches\n\n", result.rows.len()));
+        }
 
         for row in &result.rows {
             let node_type = row.first().and_then(|v| v.as_str()).unwrap_or("?");

--- a/mu-cli/src/commands/mcp/tools_v3.rs
+++ b/mu-cli/src/commands/mcp/tools_v3.rs
@@ -1034,7 +1034,10 @@ pub fn read_nodes_tool(
         return Ok(out);
     }
 
-    let resp = build_read_response(mubase, project_root, node_ids, mode)?;
+    let mut resp = build_read_response(mubase, project_root, node_ids, mode)?;
+    // Percentile ranks keep mu_read's importance consistent with mu_grok
+    // (raw scores read as 0.00 for most nodes on large graphs).
+    apply_importance_percentiles(mubase, resp.nodes.iter_mut().map(|rn| &mut rn.node));
 
     // Check for not-found nodes
     let found_ids: HashSet<&str> = resp

--- a/mu-cli/src/engine/staleness.rs
+++ b/mu-cli/src/engine/staleness.rs
@@ -38,8 +38,18 @@ pub fn check_staleness(
     let scan = mu_core::scanner::scan_with_options(root_str, options)
         .map_err(|e| anyhow::anyhow!("staleness scan failed: {}", e))?;
 
+    // The scanner also collects doc/config files (markdown, yaml, json, toml)
+    // that the parser never turns into nodes; a stale README must not tell the
+    // user the graph is outdated. Only count files the parser would index.
+    let parseable = mu_core::parser::supported_languages();
+
     let mut stale = 0usize;
+    let mut total = 0usize;
     for file in &scan.files {
+        if !parseable.contains(&file.language.as_str()) {
+            continue;
+        }
+        total += 1;
         let mtime = std::fs::metadata(root.join(&file.path))
             .and_then(|m| m.modified())
             .ok()
@@ -53,7 +63,7 @@ pub fn check_staleness(
 
     Ok(StalenessReport {
         stale_files: stale,
-        total_files: scan.files.len(),
+        total_files: total,
     })
 }
 
@@ -93,5 +103,21 @@ mod tests {
         let report = check_staleness(dir.path(), 1, vec![]).unwrap();
         assert_eq!(report.total_files, 0);
         assert!(!report.is_stale());
+    }
+
+    #[test]
+    fn test_doc_and_config_files_do_not_count_as_stale() {
+        // The scanner collects these, but the parser never indexes them, so
+        // they must not trip the "re-bootstrap your index" warning.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("README.md"), "# docs").unwrap();
+        std::fs::write(dir.path().join("config.yaml"), "a: 1").unwrap();
+        std::fs::write(dir.path().join("data.json"), "{}").unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "[package]").unwrap();
+        std::fs::write(dir.path().join("a.py"), "def f():\n    pass\n").unwrap();
+
+        let report = check_staleness(dir.path(), 1, vec![]).unwrap();
+        assert_eq!(report.total_files, 1, "only the .py file is parseable");
+        assert_eq!(report.stale_files, 1);
     }
 }

--- a/mu-cli/src/engine/storage/mubase.rs
+++ b/mu-cli/src/engine/storage/mubase.rs
@@ -631,16 +631,25 @@ impl MUbase {
 
             let mut row_data = Vec::new();
             for i in 0..column_count {
-                let value = if let Ok(v) = row.get::<_, String>(i) {
-                    serde_json::Value::String(v)
-                } else if let Ok(v) = row.get::<_, i64>(i) {
-                    serde_json::Value::Number(v.into())
-                } else if let Ok(v) = row.get::<_, f64>(i) {
-                    serde_json::json!(v)
-                } else if let Ok(v) = row.get::<_, bool>(i) {
-                    serde_json::Value::Bool(v)
-                } else {
-                    serde_json::Value::Null
+                // FLOAT/DOUBLE must be read by their actual type: the blind
+                // get::<i64> coercion truncates them (importance_score came
+                // back as 0 for every node), so check the column type first.
+                let value = match row.get_ref(i) {
+                    Ok(duckdb::types::ValueRef::Float(v)) => serde_json::json!(v as f64),
+                    Ok(duckdb::types::ValueRef::Double(v)) => serde_json::json!(v),
+                    _ => {
+                        if let Ok(v) = row.get::<_, String>(i) {
+                            serde_json::Value::String(v)
+                        } else if let Ok(v) = row.get::<_, i64>(i) {
+                            serde_json::Value::Number(v.into())
+                        } else if let Ok(v) = row.get::<_, f64>(i) {
+                            serde_json::json!(v)
+                        } else if let Ok(v) = row.get::<_, bool>(i) {
+                            serde_json::Value::Bool(v)
+                        } else {
+                            serde_json::Value::Null
+                        }
+                    }
                 };
                 row_data.push(value);
             }
@@ -741,6 +750,26 @@ mod tests {
         let stats = db.stats().unwrap();
         assert_eq!(stats.node_count, 2);
         assert_eq!(stats.edge_count, 1);
+    }
+
+    #[test]
+    fn test_float_columns_survive_generic_row_collection() {
+        // importance_score is a FLOAT (f32) column; duckdb-rs does not coerce
+        // it to f64, so collect_rows needs an explicit f32 arm. Regression
+        // test for mu_read showing "importance: 0.00" on every node.
+        let db = create_test_db();
+        let node = Node::module("src/a.py");
+        db.insert_nodes(&[node]).unwrap();
+        db.query("UPDATE nodes SET importance_score = 0.53 WHERE id = 'mod:src/a.py'")
+            .unwrap();
+
+        let result = db
+            .query("SELECT importance_score FROM nodes WHERE id = 'mod:src/a.py'")
+            .unwrap();
+        let value = result.rows[0][0]
+            .as_f64()
+            .expect("FLOAT column must come back as a JSON number, not Null");
+        assert!((value - 0.53).abs() < 1e-6);
     }
 
     #[test]

--- a/mu-core/src/parser/csharp.rs
+++ b/mu-core/src/parser/csharp.rs
@@ -652,6 +652,7 @@ fn extract_invocation_call_site(node: &Node, source: &str) -> Option<CallSiteDef
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         "member_access_expression" | "member_binding_expression" => {
@@ -684,6 +685,7 @@ fn extract_invocation_call_site(node: &Node, source: &str) -> Option<CallSiteDef
                 line,
                 is_method_call: true,
                 receiver,
+                arg_refs: Vec::new(),
             })
         }
         "conditional_access_expression" => {
@@ -709,6 +711,7 @@ fn extract_invocation_call_site(node: &Node, source: &str) -> Option<CallSiteDef
                 line,
                 is_method_call: true,
                 receiver,
+                arg_refs: Vec::new(),
             })
         }
         "generic_name" => {
@@ -719,6 +722,7 @@ fn extract_invocation_call_site(node: &Node, source: &str) -> Option<CallSiteDef
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         _ => {
@@ -729,6 +733,7 @@ fn extract_invocation_call_site(node: &Node, source: &str) -> Option<CallSiteDef
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
     }
@@ -751,6 +756,7 @@ fn extract_object_creation_call_site(node: &Node, source: &str) -> Option<CallSi
         line,
         is_method_call: false,
         receiver: None,
+        arg_refs: Vec::new(),
     })
 }
 

--- a/mu-core/src/parser/go.rs
+++ b/mu-core/src/parser/go.rs
@@ -550,6 +550,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         "selector_expression" => {
@@ -565,6 +566,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: true,
                 receiver,
+                arg_refs: Vec::new(),
             })
         }
         "parenthesized_expression" => {
@@ -575,6 +577,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         "call_expression" => {
@@ -585,6 +588,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         "index_expression" => {
@@ -595,6 +599,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         "type_assertion_expression" => {
@@ -605,6 +610,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         _ => {
@@ -615,6 +621,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
     }

--- a/mu-core/src/parser/java.rs
+++ b/mu-core/src/parser/java.rs
@@ -498,6 +498,7 @@ fn extract_method_invocation(node: &Node, source: &str) -> Option<CallSiteDef> {
         line,
         is_method_call: receiver.is_some(),
         receiver,
+        arg_refs: Vec::new(),
     })
 }
 
@@ -517,6 +518,7 @@ fn extract_object_creation(node: &Node, source: &str) -> Option<CallSiteDef> {
                     line,
                     is_method_call: false,
                     receiver: None,
+                    arg_refs: Vec::new(),
                 });
             }
             "generic_type" => {
@@ -528,6 +530,7 @@ fn extract_object_creation(node: &Node, source: &str) -> Option<CallSiteDef> {
                         line,
                         is_method_call: false,
                         receiver: None,
+                        arg_refs: Vec::new(),
                     });
                 }
             }
@@ -539,6 +542,7 @@ fn extract_object_creation(node: &Node, source: &str) -> Option<CallSiteDef> {
                     line,
                     is_method_call: false,
                     receiver: None,
+                    arg_refs: Vec::new(),
                 });
             }
             _ => {}

--- a/mu-core/src/parser/python.rs
+++ b/mu-core/src/parser/python.rs
@@ -682,11 +682,39 @@ fn find_call_sites_recursive(node: &Node, source: &str, results: &mut Vec<CallSi
     }
 }
 
+/// Collect bare identifiers passed as arguments (positional or keyword
+/// values). These are potential function references: callback registration
+/// like `event.listen(Session, "do_orm_execute", my_hook)` is invisible to
+/// call-edge extraction otherwise. The resolver decides which identifiers
+/// actually name functions.
+fn extract_arg_refs(call_node: &Node, source: &str) -> Vec<String> {
+    let Some(args) = call_node.child_by_field_name("arguments") else {
+        return Vec::new();
+    };
+    let mut refs = Vec::new();
+    let mut cursor = args.walk();
+    for child in args.children(&mut cursor) {
+        match child.kind() {
+            "identifier" => refs.push(get_node_text(&child, source).to_string()),
+            "keyword_argument" => {
+                if let Some(value) = child.child_by_field_name("value") {
+                    if value.kind() == "identifier" {
+                        refs.push(get_node_text(&value, source).to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    refs
+}
+
 /// Extract a single call site from a call node.
 fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
     // The function being called is in the first child (before argument_list)
     let func_node = node.child(0)?;
     let line = get_start_line(node);
+    let arg_refs = extract_arg_refs(node, source);
 
     match func_node.kind() {
         "identifier" => {
@@ -697,6 +725,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs,
             })
         }
         "attribute" => {
@@ -728,6 +757,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: true,
                 receiver,
+                arg_refs,
             })
         }
         _ => {
@@ -738,6 +768,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs,
             })
         }
     }
@@ -758,6 +789,32 @@ def hello(name: str) -> str:
         assert_eq!(result.functions.len(), 1);
         assert_eq!(result.functions[0].name, "hello");
         assert_eq!(result.functions[0].return_type, Some("str".to_string()));
+    }
+
+    #[test]
+    fn test_call_site_captures_identifier_arg_refs() {
+        // Callback registration: the identifier argument must be captured so
+        // the graph can link `event.listen(..., my_hook)` to my_hook.
+        let source = r#"
+def register(session):
+    event.listen(Session, "do_orm_execute", my_hook)
+    schedule(callback=other_hook, retries=3)
+"#;
+        let result = parse(source, "test.py").unwrap();
+        let calls = &result.functions[0].call_sites;
+        let listen = calls.iter().find(|c| c.callee.contains("listen")).unwrap();
+        assert!(listen.arg_refs.contains(&"Session".to_string()));
+        assert!(listen.arg_refs.contains(&"my_hook".to_string()));
+        // String literals are not identifiers
+        assert!(!listen.arg_refs.iter().any(|a| a.contains("do_orm")));
+
+        let schedule = calls
+            .iter()
+            .find(|c| c.callee.contains("schedule"))
+            .unwrap();
+        assert!(schedule.arg_refs.contains(&"other_hook".to_string()));
+        // Literal keyword values are not identifiers
+        assert_eq!(schedule.arg_refs.len(), 1);
     }
 
     #[test]

--- a/mu-core/src/parser/rust_lang.rs
+++ b/mu-core/src/parser/rust_lang.rs
@@ -733,6 +733,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         "field_expression" => {
@@ -763,6 +764,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: true,
                 receiver,
+                arg_refs: Vec::new(),
             })
         }
         "scoped_identifier" => {
@@ -783,6 +785,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: receiver.is_some(),
                 receiver,
+                arg_refs: Vec::new(),
             })
         }
         "generic_function" => {
@@ -814,6 +817,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                         line,
                         is_method_call: true,
                         receiver,
+                        arg_refs: Vec::new(),
                     });
                 }
             }
@@ -823,6 +827,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         "parenthesized_expression" => {
@@ -833,6 +838,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         "call_expression" => {
@@ -843,6 +849,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         "index_expression" => {
@@ -853,6 +860,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         _ => {
@@ -863,6 +871,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
     }
@@ -893,6 +902,7 @@ fn extract_macro_invocation(node: &Node, source: &str) -> Option<CallSiteDef> {
         line,
         is_method_call: is_scoped,
         receiver,
+        arg_refs: Vec::new(),
     })
 }
 

--- a/mu-core/src/parser/typescript.rs
+++ b/mu-core/src/parser/typescript.rs
@@ -716,6 +716,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
         "member_expression" => {
@@ -743,6 +744,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: true,
                 receiver,
+                arg_refs: Vec::new(),
             })
         }
         _ => {
@@ -753,6 +755,7 @@ fn extract_call_site(node: &Node, source: &str) -> Option<CallSiteDef> {
                 line,
                 is_method_call: false,
                 receiver: None,
+                arg_refs: Vec::new(),
             })
         }
     }

--- a/mu-core/src/types.rs
+++ b/mu-core/src/types.rs
@@ -44,6 +44,12 @@ pub struct CallSiteDef {
     pub is_method_call: bool,
     /// The receiver, e.g., "self", "user_service"
     pub receiver: Option<String>,
+    /// Bare identifiers passed as arguments (positional or keyword values).
+    /// Lets the graph link callback registration (`event.listen(..., my_hook)`)
+    /// to the referenced function. `serde(default)` keeps old parse caches
+    /// deserializable.
+    #[serde(default)]
+    pub arg_refs: Vec<String>,
 }
 
 impl CallSiteDef {
@@ -53,6 +59,7 @@ impl CallSiteDef {
             line,
             is_method_call,
             receiver,
+            arg_refs: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
Four fixes from the second BP dogfooding round, one commit per issue. Stacked on #40 (the callback/typed-receiver resolution builds on its module index) - merge #40 first, then retarget or merge this into develop.

## What each commit fixes

**#41 - staleness counted files MU never indexes.** The scanner collects markdown/yaml/json/toml; the parser doesn't. Touching a README told users to re-bootstrap. Staleness now filters to parser-supported languages. Verified: `touch docs/RUNBOOK.md` -> no warning, `touch main.py` -> warns.

**#42 - mu_find hid production matches.** `FIND_SYMBOL_SQL` was `LIMIT 10` with no `ORDER BY`, so `chat` returned 10 test stubs and omitted both production implementations silently. Now orders production-first then importance, and reports "16 matches (10 shown, production-first; 6 omitted)".

**#43 - every importance read as 0.00 through query_params.** Root cause was nastier than the report: `collect_rows` probes `get::<i64>` before floats, and duckdb-rs truncates FLOAT to i64 - so importance_score came back as integer 0 everywhere, including the percentile table behind mu_grok's imp=pNN tags. Now reads Float/Double by actual column type via `get_ref`. mu_read also renders `imp=pNN` like the rest of the toolchain.

**#44 - callback registration and typed-receiver calls had no edges.** Two parts:
- Python call sites now capture bare identifier arguments; precisely-resolvable ones (same module or explicit import) get `uses` edges. `mu impact _apply_tenant_filter` went from 1 node to 12, now including `register_tenant_filter` and the app lifespan that installs it.
- `x.m()` resolves through the enclosing function's parameter annotations (`Optional[X]`, `X | None`, dotted, quoted forms). `ToolInvoker.invoke` (protocol) went from zero incoming call edges to its two real production callers.

## Verification

BP codebase re-indexed with `--force`: 8,035 edges (7,855 after #40, 6,581 before). All 455 tests pass, clippy clean, both crates. New tests: staleness doc-file filtering, FLOAT round-trip regression, arg-ref extraction and resolution, annotation parsing, annotated-receiver resolution.